### PR TITLE
Preserve XML tags during SLP1 round-trip conversion

### DIFF
--- a/scripts/test_to_slp1_markup.py
+++ b/scripts/test_to_slp1_markup.py
@@ -1,0 +1,67 @@
+# coding=utf-8
+import unittest
+
+from to_slp1 import (
+    convert_partially_to_slp1,
+    convert_to_slp1,
+    transliterate_text_preserving_xml_tags,
+)
+
+
+class ToSlp1MarkupTest(unittest.TestCase):
+    def test_plain_devanagari_text_converts(self):
+        self.assertEqual(
+            transliterate_text_preserving_xml_tags('राम गच्छति', 'slp1_accented'),
+            'rAma gacCati',
+        )
+
+    def test_segment_tags_are_preserved(self):
+        self.assertEqual(
+            convert_partially_to_slp1('<s>', '</s>', 'slp1_accented', '<s>राम</s>'),
+            '<s>rAma</s>',
+        )
+
+    def test_embedded_xml_tags_are_preserved_inside_segment(self):
+        self.assertEqual(
+            convert_partially_to_slp1(
+                '<s>',
+                '</s>',
+                'slp1_accented',
+                '<s>राम <ab>देव</ab> गच्छति</s>',
+            ),
+            '<s>rAma <ab>deva</ab> gacCati</s>',
+        )
+
+    def test_whole_line_conversion_preserves_xml_tags(self):
+        self.assertEqual(
+            convert_to_slp1('राम <info n="1">गच्छति</info><lex>देव</lex><lb/>'),
+            'rAma <info n="1">gacCati</info><lex>deva</lex><lb/>',
+        )
+
+    def test_metaline_tags_are_preserved(self):
+        self.assertEqual(
+            transliterate_text_preserving_xml_tags(
+                '<L>1<pc>1<k1>राम<k2>राꣳम<e>1',
+                'slp1_accented',
+            ),
+            '<L>1<pc>1<k1>rAma<k2>rAM£ma<e>1',
+        )
+
+    def test_skip_lines_remain_unchanged(self):
+        data = '\n'.join([
+            '<L>1<pc>1<k1>राम<k2>राम',
+            '[Page1-a+ 1]',
+            '<H>राम',
+            '<LEND>',
+        ])
+        self.assertEqual(convert_to_slp1(data), data)
+
+    def test_vedic_anusvara_marker_converts_to_accented_slp1(self):
+        self.assertEqual(
+            transliterate_text_preserving_xml_tags('देवाꣳसो', 'slp1_accented'),
+            'devAM£so',
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/scripts/to_slp1.py
+++ b/scripts/to_slp1.py
@@ -12,6 +12,22 @@ import os
 import re
 from indic_transliteration import sanscript
 
+XML_TAG_RE = re.compile(r'(<[^<>]*>)')
+
+
+def transliterate_text_preserving_xml_tags(text, outputTranslit):
+    """Transliterate text nodes while preserving XML-like tags."""
+    parts = XML_TAG_RE.split(text)
+    result = []
+    for part in parts:
+        if not part:
+            continue
+        if XML_TAG_RE.fullmatch(part):
+            result.append(part)
+        else:
+            result.append(sanscript.transliterate(part, 'devanagari', outputTranslit))
+    return ''.join(result)
+
 
 def convert_metaline(dictcode):
     """Convert metaline k1 and k2 to SLP1."""
@@ -27,7 +43,7 @@ def convert_metaline(dictcode):
         # If metaline,
         if lin.startswith('<L>'):
             # Convert to slp1
-            result.append(sanscript.transliterate(lin, 'devanagari', 'slp1_accented'))
+            result.append(transliterate_text_preserving_xml_tags(lin, 'slp1_accented'))
         else:
             # If not metaline, keep it as it is.
             result.append(lin)
@@ -49,7 +65,7 @@ def convert_to_slp1(data):
         # If change required,
         else:
             # Convert to SLP1.
-            result.append(sanscript.transliterate(lin, 'devanagari', 'slp1_accented'))
+            result.append(transliterate_text_preserving_xml_tags(lin, 'slp1_accented'))
     # Return the result
     return '\n'.join(result)
 
@@ -71,7 +87,7 @@ def convert_partially_to_slp1(startMark, endMark, outputTranslit, data):
             textToConvert = re.sub('^' + startMark, '', splt[i])
             textToConvert = re.sub(endMark + '$', '', textToConvert)
             # Transliterate to SLP1
-            result.append(startMark + sanscript.transliterate(textToConvert, 'devanagari', outputTranslit) + endMark)
+            result.append(startMark + transliterate_text_preserving_xml_tags(textToConvert, outputTranslit) + endMark)
     # Return output
     return ''.join(result)
 


### PR DESCRIPTION
Addresses the reverse-conversion side of sanskrit-lexicon/csl-devanagari#41 and sanskrit-lexicon/csl-devanagari#43.

## Summary
- preserve XML-like tags while transliterating Devanagari text nodes back to SLP1-accented text
- cover plain text, `<s>...</s>` segments, embedded XML tags, whole-line conversion, metalines, skipped metadata lines, and the U+A8F3 Vedic anusvara marker (`ꣳ` → `M£`)

## Validation
- `python -m unittest discover -s scripts -p "test*.py"`
- `python -m py_compile scripts/to_slp1.py`

## Note
This is intentionally a converter-script PR only. I did not include regenerated `v02/*` outputs because full clean regeneration also depends on the forward-conversion tag-preservation fix in PR #45.