### PR TITLE
docs: correct README creation date (H549 audit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # csl-devanagari
 
-_Created: 26-11-2019 · Last updated: 05-07-2026_
+_Created: 02-09-2021 · Last updated: 11-07-2026_
 
 ## Why this repo exists
 


### PR DESCRIPTION
Part of the **H549** README audit+refactor sweep across csl-* tooling repos ([handoff](https://github.com/gasyoun/Uprava/blob/main/handoffs/H549-Opus_Uprava_readme-refresh-tooling-repos_10.07.26.md)).

## Finding

The current [README.md](https://github.com/sanskrit-lexicon/csl-devanagari/blob/main/README.md) on `main` (from #47) is already org-compliant — dated header, byline, no raw HTML, full blob URLs, and a verified usage example. Auditing every claim against `origin/main`, they all hold **except the creation date**:

- Header claimed `Created: 26-11-2019`
- GitHub repo `created_at` = **2021-09-02**, and the earliest commit (`git log --reverse`) is also **2021-09-02**

There is no evidence for a 2019 inception, so this corrects the date to `02-09-2021` and bumps `Last updated` to today.

## Verified true (left unchanged)

- `v02/mw/mw.txt` = **880,516 lines** (matches the README's worked example)
- All referenced files exist on `main`: [to_devanagari.py](https://github.com/sanskrit-lexicon/csl-devanagari/blob/main/scripts/to_devanagari.py), [to_slp1.py](https://github.com/sanskrit-lexicon/csl-devanagari/blob/main/scripts/to_slp1.py), [redo.sh](https://github.com/sanskrit-lexicon/csl-devanagari/blob/main/scripts/redo.sh), [redo_all.sh](https://github.com/sanskrit-lexicon/csl-devanagari/blob/main/scripts/redo_all.sh), [diff/mw.txt](https://github.com/sanskrit-lexicon/csl-devanagari/blob/main/diff/mw.txt)

No MANUAL markers present; no README-guard CI. Single-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)